### PR TITLE
fix: mobile layout tweaks homepage

### DIFF
--- a/src/components/CardJobs.tsx
+++ b/src/components/CardJobs.tsx
@@ -1,6 +1,7 @@
 import { TJobs } from '@/types'
 import { BackpackIcon } from '@radix-ui/react-icons'
 import Link from 'next/link'
+import { InfoLabel } from './InfoLabel'
 
 type OwnerProps = {
   Owner: boolean
@@ -20,22 +21,16 @@ export const CardJobs = ({
       href={Owner ? `dashboard/work/${ID}` : `work/${ID}`}
       className="w-full relative gap-5 hover:translate-y-[-6px] ease-out duration-200 hover:bg-zinc-900/50 group px-6 py-6 flex flex-col  rounded-lg bg-zinc-900 border border-zinc-800"
     >
-      <div className="w-full flex  flex-col gap-1">
+      <div className="w-full flex flex-col gap-1 max-sm:">
         <h1 className="text-2xl font-bold text-zinc-200 ">{Title}</h1>
         <p className="text-zinc-400 font-normal text-sm line-clamp-3">
           {Description}
         </p>
       </div>
-      <div className="flex items-center gap-3 justify-start">
-        <p className="bg-zinc-800 group-hover:bg-zinc-900 ease-out duration-150 group-hover:text-emerald-400 px-3 py-1 text-zinc-400 text-base rounded-md">
-          {Company}
-        </p>
-        <p className="bg-zinc-800 flex items-center justify-center gap-2 group-hover:bg-zinc-900 ease-out duration-150 group-hover:text-emerald-400 px-3 py-1 text-zinc-400 text-base rounded-md">
-          <BackpackIcon width={20} height={20} /> {Role}
-        </p>
-        <p className="bg-zinc-800 group-hover:bg-zinc-900 ease-out duration-150 group-hover:text-emerald-400 px-3 py-1 text-zinc-400 text-base rounded-md">
-          {!Remote ? 'Presencial' : 'Remoto'}
-        </p>
+      <div className="flex max-sm:flex-row items-center gap-3 justify-start">
+        <InfoLabel info={Company} />
+        <InfoLabel info={Role} icon={<BackpackIcon width={20} height={20} />} />
+        <InfoLabel info={!Remote ? 'Presencial' : 'Remoto'} />
       </div>
     </Link>
   )

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,8 +1,7 @@
 'use client'
 import { motion } from 'framer-motion'
-import { GitHubLogoIcon } from '@radix-ui/react-icons'
 import Link from 'next/link'
-import DialogButton from './ModalJobs'
+import { Menu } from './Menu'
 
 export const Header = () => {
   return (
@@ -25,18 +24,7 @@ export const Header = () => {
           </motion.span>
         </h1>
       </Link>
-      <div className="flex gap-3">
-        <a
-          className="flex font-bold active:scale-95 ease-out gap-2 items-center justify-center bg-zinc-900 py-3 px-5 hover:bg-zinc-800 duration-150 ease-out rounded-md text-base"
-          href="https://github.com/revogabe"
-          target="_blank"
-          rel="noreferrer"
-        >
-          <GitHubLogoIcon width={20} height={20} />
-          Github
-        </a>
-        <DialogButton />
-      </div>
+      <Menu />
     </header>
   )
 }

--- a/src/components/InfoLabel.tsx
+++ b/src/components/InfoLabel.tsx
@@ -1,0 +1,17 @@
+import { ReactNode } from 'react'
+
+type InfoLabelProps = {
+  info: string
+  icon?: ReactNode
+}
+
+export const InfoLabel = ({ info, icon }: InfoLabelProps) => {
+  const classIcon = icon
+    ? 'bg-zinc-800 max-sm:w-1/3 max-sm:truncate flex items-center justify-center gap-2 group-hover:bg-zinc-900 ease-out duration-150 group-hover:text-emerald-400 px-3 py-1 text-zinc-400 text-base rounded-md'
+    : 'bg-zinc-800 max-sm:w-1/3 max-sm:truncate max-sm:text-center group-hover:bg-zinc-900 ease-out duration-150 group-hover:text-emerald-400 px-3 py-1 text-zinc-400 text-base rounded-md'
+  return (
+    <p className={classIcon}>
+      {icon} {info}
+    </p>
+  )
+}

--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -1,0 +1,37 @@
+import { GitHubLogoIcon } from '@radix-ui/react-icons'
+import DialogButton from './ModalJobs'
+import { useMobile } from '@/hooks/useMobile'
+
+export const Menu = () => {
+  const { isMobile } = useMobile()
+  if (isMobile) {
+    return (
+      <div className="flex gap-3">
+        <a
+          className="flex font-bold active:scale-95 gap-2 items-center justify-center bg-zinc-900 py-3 px-5 hover:bg-zinc-800 duration-150 ease-out rounded-md text-base"
+          href="https://github.com/revogabe"
+          target="_blank"
+          rel="noreferrer"
+        >
+          <GitHubLogoIcon width={20} height={20} />
+        </a>
+        <DialogButton />
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex gap-3">
+      <a
+        className="flex font-bold active:scale-95 gap-2 items-center justify-center bg-zinc-900 py-3 px-5 hover:bg-zinc-800 duration-150 ease-out rounded-md text-base"
+        href="https://github.com/revogabe"
+        target="_blank"
+        rel="noreferrer"
+      >
+        <GitHubLogoIcon width={20} height={20} />
+        Github
+      </a>
+      <DialogButton />
+    </div>
+  )
+}

--- a/src/components/ModalJobs.tsx
+++ b/src/components/ModalJobs.tsx
@@ -3,9 +3,11 @@ import React from 'react'
 import * as Dialog from '@radix-ui/react-dialog'
 import { Cross2Icon, PlusCircledIcon } from '@radix-ui/react-icons'
 import { TJobsRequest } from '@/types'
+import { useMobile } from '@/hooks/useMobile'
 
 const DialogButton = () => {
   const [isPending, setIsPending] = React.useState(false)
+  const { isMobile } = useMobile()
 
   async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault()
@@ -16,7 +18,6 @@ const DialogButton = () => {
       method: 'POST',
       body: JSON.stringify({ ...data, remote: !!data.remote }),
     })
-    console.log(data.remote)
     setIsPending(true)
   }
 
@@ -28,7 +29,7 @@ const DialogButton = () => {
           rel="noreferrer"
         >
           <PlusCircledIcon width={20} height={20} />
-          Postar Vaga
+          {!isMobile && 'Postar Vaga'}
         </button>
       </Dialog.Trigger>
       <Dialog.Portal>

--- a/src/hooks/useMobile.ts
+++ b/src/hooks/useMobile.ts
@@ -1,0 +1,23 @@
+import { useEffect, useState } from 'react'
+
+const MAX_MOBILE_WIDTH = 640
+
+export const useMobile = () => {
+  const [width, setWidth] = useState<number>(0)
+
+  function handleWindowSizeChange() {
+    setWidth(window.innerWidth)
+  }
+  useEffect(() => {
+    if (window) {
+      setWidth(window.innerWidth)
+      window.addEventListener('resize', handleWindowSizeChange)
+      return () => {
+        window.removeEventListener('resize', handleWindowSizeChange)
+      }
+    }
+  }, [])
+
+  const isMobile = width <= MAX_MOBILE_WIDTH
+  return { isMobile }
+}


### PR DESCRIPTION
Altera o layout para mobile da homepage, os seguintes ajustes foram feitos:

### Alterações de layout
- As labels de informações foram alteradas para funcionarem como linhas, para ter uma melhor legibilidade, pois ao usar telas pequenas devemos usar mias linhas nos lugares de colunas.
- O botão do github e da criação foram deixados apenas com os respectivos ícones para não sobrescrever a logo do header.

### Alterações no projeto
- Foi adicionado no projeto um hook que detecta se com a largura mobile
- As labels de informações foram componentizadas
- Os botões de criação e github do Header foram componentizados

<table>
	<thead>
		<tr>
			<th>Antes</th>
			<th>Depois</th>
		</tr>
	</thead>
	<tbody>
		<tr>
			<td><img src="https://user-images.githubusercontent.com/82042005/234940999-d833e970-e08f-4200-ac29-2fe43df20e3b.png" alt="Imagem Antes"></td>
			<td><img src="https://user-images.githubusercontent.com/82042005/234940722-42e92002-0f00-4638-8a85-a2804542ac93.png"></td>
		</tr>
	</tbody>
</table>